### PR TITLE
map group to company api

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -117,11 +117,17 @@ Trakio.prototype.identify = function(identify) {
  *
  * @param {String} id (optional)
  * @param {Object} properties (optional)
- * @param {Object} options (optional)
+ * http://docs.trak.io/company.html
  *
- * TODO: add group
- * TODO: add `trait.company/organization` from trak.io docs http://docs.trak.io/properties.html#special
  */
+
+Trakio.prototype.group = function(group) {
+  var traits = group.traits();
+  delete traits.id;
+  var id = group.groupId();
+  if (id) window.trak.io.company_id(id);
+  window.trak.io.company(traits);
+};
 
 /**
  * Track.

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -182,6 +182,31 @@ describe('trak.io', function() {
       });
     });
 
+    describe('#group', function() {
+      beforeEach(function() {
+        analytics.stub(window.trak.io, 'company_id');
+        analytics.stub(window.trak.io, 'company');
+      });
+
+      it('should send company id', function() {
+        analytics.group('segment');
+        analytics.called(window.trak.io.company_id, 'segment');
+      });
+
+      it('should send company traits', function() {
+        analytics.group({ name: 'segment' });
+        analytics.called(window.trak.io.company, { name: 'segment' });
+      });
+
+      it('should send both company id and traits', function() {
+        analytics.group('seggy123', {
+          name: 'segment'
+        });
+        analytics.called(window.trak.io.company_id, 'seggy123');
+        analytics.called(window.trak.io.company, { name: 'segment' });
+      });
+    });
+
     describe('#alias', function() {
       beforeEach(function() {
         analytics.stub(window.trak.io, 'distinct_id');


### PR DESCRIPTION
Pretty no brainer mapping here: http://docs.trak.io/company.html

delete traits.id since we don't want to send duplicate traits since `id` is registered by `company_id()` if it exists.

todo:
- [ ] update docs

@segment-integrations/core 
