### PR TITLE
Rename integration to match metadata slug

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# analytics.js-integration-trakio [![Build Status][ci-badge]][ci-link]
+# analytics.js-integration-trak-io [![Build Status][ci-badge]][ci-link]
 
 Trakio integration for [Analytics.js][].
 
@@ -8,5 +8,5 @@ Released under the [MIT license](LICENSE).
 
 
 [Analytics.js]: https://segment.com/docs/libraries/analytics.js/
-[ci-link]: https://circleci.com/gh/segment-integrations/analytics.js-integration-trakio
-[ci-badge]: https://circleci.com/gh/segment-integrations/analytics.js-integration-trakio.svg?style=svg
+[ci-link]: https://circleci.com/gh/segment-integrations/analytics.js-integration-trak-io
+[ci-badge]: https://circleci.com/gh/segment-integrations/analytics.js-integration-trak-io.svg?style=svg

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "@segment/analytics.js-integration-trakio",
-  "description": "The Trakio analytics.js integration.",
+  "name": "@segment/analytics.js-integration-trak-io",
+  "description": "The Trak.io analytics.js integration.",
   "version": "2.0.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",
     "segment",
-    "trakio"
+    "trak.io"
   ],
   "main": "lib/index.js",
   "scripts": {
@@ -14,14 +14,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/segment-integrations/analytics.js-integration-trakio.git"
+    "url": "git+https://github.com/segment-integrations/analytics.js-integration-trak-io.git"
   },
   "author": "Segment <friends@segment.com>",
   "license": "SEE LICENSE IN LICENSE",
   "bugs": {
-    "url": "https://github.com/segment-integrations/analytics.js-integration-trakio/issues"
+    "url": "https://github.com/segment-integrations/analytics.js-integration-trak-io/issues"
   },
-  "homepage": "https://github.com/segment-integrations/analytics.js-integration-trakio#readme",
+  "homepage": "https://github.com/segment-integrations/analytics.js-integration-trak-io#readme",
   "dependencies": {
     "@segment/alias": "^1.0.1",
     "@segment/analytics.js-integration": "^2.1.0"


### PR DESCRIPTION
After merging this we should:
- Run `npm deprecate @segment/analytics.js-integration-trakio "@segment/analytics.js-integration-trakio has been renamed. Use @segment/analytics.js-integration-trak-io instead."`
- Rename this repository to `analytics.js-integration-trakio`
- Issue a `3.0.0` release
